### PR TITLE
Integrate Spider dataset preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ This repository contains a simple chat application with a FastAPI backend and a 
 
 ## Fine-tuning Qwen on Spider
 
-A script is provided to fine-tune a Qwen model on the Spider text-to-SQL dataset. Prepare your dataset as JSONL files containing `prompt` and `response` fields and run:
+A script is provided to fine-tune a Qwen model on the Spider text-to-SQL dataset.
+The raw Spider files are included under `spider_data/`. Convert them into the
+required JSONL format using `prepare_spider_jsonl.py`:
+
+```bash
+python backend/scripts/prepare_spider_jsonl.py --spider-dir spider_data --output-dir .
+```
+
+This will generate `spider_train.jsonl` and `spider_val.jsonl` containing
+`prompt` and `response` fields. Then run the training script:
 
 ```bash
 python backend/scripts/train_qwen_spider.py \

--- a/backend/scripts/prepare_spider_jsonl.py
+++ b/backend/scripts/prepare_spider_jsonl.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+import argparse
+
+
+def load_schema(tables_path: Path) -> dict:
+    """Return mapping of db_id -> schema string."""
+    with open(tables_path, 'r') as f:
+        tables = json.load(f)
+
+    schemas = {}
+    for db in tables:
+        table_names = db["table_names_original"]
+        columns = db["column_names_original"]
+        parts = []
+        for idx, table_name in enumerate(table_names):
+            cols = [col for tbl_idx, col in columns if tbl_idx == idx and col != "*"]
+            parts.append(f"{table_name}({','.join(cols)})")
+        schemas[db["db_id"]] = " ".join(parts)
+    return schemas
+
+
+def convert(json_file: Path, schema_map: dict):
+    with open(json_file, 'r') as f:
+        examples = json.load(f)
+
+    for ex in examples:
+        db = ex["db_id"]
+        schema = schema_map[db]
+        prompt = f"Schema: {schema}\nQuestion: {ex['question']}\nSQL:"
+        yield {"prompt": prompt, "response": ex["query"]}
+
+
+def dump_jsonl(files, out_path: Path, schema_map: dict):
+    with open(out_path, 'w') as f:
+        for jf in files:
+            for item in convert(jf, schema_map):
+                json.dump(item, f)
+                f.write('\n')
+
+
+def main(args):
+    spider_dir = Path(args.spider_dir)
+    schema_map = load_schema(spider_dir / 'tables.json')
+
+    train_files = [spider_dir / 'train_spider.json', spider_dir / 'train_others.json']
+    val_files = [spider_dir / 'dev.json']
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    dump_jsonl(train_files, out_dir / args.train_file, schema_map)
+    dump_jsonl(val_files, out_dir / args.val_file, schema_map)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prepare Spider dataset in JSONL format for training.')
+    parser.add_argument('--spider-dir', default='spider_data', help='Path to raw Spider dataset directory')
+    parser.add_argument('--output-dir', default='.', help='Directory to save JSONL files')
+    parser.add_argument('--train-file', default='spider_train.jsonl', help='Name of output training JSONL file')
+    parser.add_argument('--val-file', default='spider_val.jsonl', help='Name of output validation JSONL file')
+
+    main(parser.parse_args())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,19 @@
+# Combined Python dependencies for the project
+# Backend environment mirrors backend/requirements.txt
+fastapi
+uvicorn
+openai
+langchain
+langchain-openai
+pydantic-settings
+python-dotenv
+langsmith
+redis
+langchain-community
+sqlalchemy
+psycopg2-binary
+alembic
+transformers
+datasets
+peft
+accelerate


### PR DESCRIPTION
## Summary
- add script to convert Spider dataset into JSONL
- document how to run dataset preparation before model training
- include project-wide `requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840f32af2388322b14ac576f8757a46